### PR TITLE
Rename env and pp definition

### DIFF
--- a/docs/12.HarddwareSONOFF.md
+++ b/docs/12.HarddwareSONOFF.md
@@ -1,9 +1,0 @@
-BrewPiLess can run on [SONOFF Basic](https://www.itead.cc/wiki/Sonoff) and [SONOFF TH10/16](https://www.itead.cc/wiki/Sonoff_TH_10/16). You will need to solder the header pins for the first flashing and install temperature sensors. However, because of the small 1M byte flash memory, you will either sacrifice 
-* OTA web update for log storage, or
-* 500k log storage for OTA update
-* LCD is not available.
-
-SONOFF dual is not supported, because the Relays are controlled by Serial instead of GPIO.Instead, SONOFF Dual **R2** should work by specify correct PINs.
-
-Please note that some older SONOFFs, maybe before 2018, use ESP8266 while new ones use ESP8285. Right configuration must be used.
-

--- a/docs/12.HardwareSONOFF.md
+++ b/docs/12.HardwareSONOFF.md
@@ -9,7 +9,7 @@ Please note that some older SONOFFs, maybe before 2018, use ESP8266 while new on
 
 ### ESP32 SonOff devices (Sonoff TH Origin and Sonoff TH Elite)
 
-For Sonoff TH Elite the built-in lcd display can be removed and a OLED LCD screen can be connected in it's place.. Use electrical tape to make sure that the LCD pcb is not touching the main pcb. 
+For Sonoff TH Elite the built-in lcd display can be removed and a OLED LCD screen can be connected in it's place.. Use electrical tape to make sure that the LCD pcb is not touching the main pcb. The front glass is a thin plastic be gentle with it. 
 
 #### Conntecting sensor
 The sensor that has the RJ9 connector comes with a controller in the wire that needs to be removed
@@ -19,4 +19,5 @@ Option 2: Use  `Sonoff AL010 2.5mm Audio Jack to RJ9 Adapter` with the old senso
 ##### Connecting OLED LCD (optional)
 * Connect SDA to WR solder pad
 * Connect SCL to CS solder pad
+* Use hotglue over soldered contacts so that you don't ripoff the solder pads accidentally. 
 * Connect 3v and Gnd to corresponding solderpads

--- a/docs/12.HardwareSONOFF.md
+++ b/docs/12.HardwareSONOFF.md
@@ -1,0 +1,22 @@
+BrewPiLess can run on [SONOFF Basic](https://www.itead.cc/wiki/Sonoff) and [SONOFF TH10/16](https://www.itead.cc/wiki/Sonoff_TH_10/16). You will need to solder the header pins for the first flashing and install temperature sensors. However, because of the small 1M byte flash memory, you will either sacrifice 
+* OTA web update for log storage, or
+* 500k log storage for OTA update
+* LCD is not available.
+
+SONOFF dual is not supported, because the Relays are controlled by Serial instead of GPIO.Instead, SONOFF Dual **R2** should work by specify correct PINs.
+
+Please note that some older SONOFFs, maybe before 2018, use ESP8266 while new ones use ESP8285. Right configuration must be used.
+
+### ESP32 SonOff devices (Sonoff TH Origin and Sonoff TH Elite)
+
+For Sonoff TH Elite the built-in lcd display can be removed and a OLED LCD screen can be connected in it's place.. Use electrical tape to make sure that the LCD pcb is not touching the main pcb. 
+
+#### Conntecting sensor
+The sensor that has the RJ9 connector comes with a controller in the wire that needs to be removed
+Option 1: Remove the controller and reconntect the wires (not tested).
+Option 2: Use  `Sonoff AL010 2.5mm Audio Jack to RJ9 Adapter` with the old sensor using the audio jack conntector.
+
+##### Connecting OLED LCD (optional)
+* Connect SDA to WR solder pad
+* Connect SCL to CS solder pad
+* Connect 3v and Gnd to corresponding solderpads

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 * [Hardware Setup](10.HardwareGeneral.md)
   * [Example#1](11.HardwareExample1.md)
-  * [SONOFF](12.HarddwareSONOFF.md)
+  * [SONOFF](12.HardwareSONOFF.md)
   * [Thorrax’s Board](https://github.com/thorrak/brewpi-esp8266)
   * [ESP32](13.ESP32Pins.md)
     * [ESP32 Build](14.ESP32BuildInstructions.md)

--- a/platformio.ini
+++ b/platformio.ini
@@ -140,7 +140,7 @@ build_flags =
 monitor_speed = 115200
 lib_deps = ${common_env_data.lib_deps_external_esp32} 
 
-[env:esp32-sonoff]  # for newgen sonoff devices like sonoff elite and origin
+[env:esp32-sonoff-th-elite_origin]  # for newgen sonoff devices like sonoff elite and origin
 platform = ${common_env_data.esp32_framework}
 board = esp32dev
 framework = arduino
@@ -155,7 +155,7 @@ build_flags =
     -DEnableHumidityControlSupport=false
     -DEanbleParasiteTempControl=false
     -DEnableBME280Support=false
-    -DSONOFF_NEWGEN=true
+    -DSONOFF_TH_ELITE_ORIGIN=true
 
 monitor_speed = 115200
 lib_deps = ${common_env_data.lib_deps_external_esp32} 

--- a/platformio.ini
+++ b/platformio.ini
@@ -60,10 +60,10 @@ upload_speed = 460800
 
 lib_deps = ${common_env_data.lib_deps_external_esp32} 
 
-upload_port = /dev/cu.SLAB_USBtoUART
-monitor_port = /dev/cu.SLAB_USBtoUART
-#upload_port = /dev/cu.usbserial-0001
-#monitor_port = /dev/cu.usbserial-0001
+#upload_port = /dev/cu.SLAB_USBtoUART
+#monitor_port = /dev/cu.SLAB_USBtoUART
+upload_port = /dev/cu.usbserial-0001
+monitor_port = /dev/cu.usbserial-0001
 #upload_port = /dev/cu.usbserial-1410
 #monitor_port = /dev/cu.usbserial-1410
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -60,10 +60,10 @@ upload_speed = 460800
 
 lib_deps = ${common_env_data.lib_deps_external_esp32} 
 
-#upload_port = /dev/cu.SLAB_USBtoUART
-#monitor_port = /dev/cu.SLAB_USBtoUART
-upload_port = /dev/cu.usbserial-0001
-monitor_port = /dev/cu.usbserial-0001
+upload_port = /dev/cu.SLAB_USBtoUART
+monitor_port = /dev/cu.SLAB_USBtoUART
+#upload_port = /dev/cu.usbserial-0001
+#monitor_port = /dev/cu.usbserial-0001
 #upload_port = /dev/cu.usbserial-1410
 #monitor_port = /dev/cu.usbserial-1410
 
@@ -135,7 +135,27 @@ lib_extra_dirs = ${common_env_data.esp32_lib}
 board_build.partitions = ./partition2.csv
 
 build_flags =
-    -DOLED_LCD=true
+    -DOLED_LCD=true 
+
+monitor_speed = 115200
+lib_deps = ${common_env_data.lib_deps_external_esp32} 
+
+[env:esp32-sonoff]  # for newgen sonoff devices like sonoff elite and origin
+platform = ${common_env_data.esp32_framework}
+board = esp32dev
+framework = arduino
+board_build.mcu = esp32
+lib_extra_dirs = ${common_env_data.esp32_lib}
+
+board_build.partitions = ./partition2.csv
+
+build_flags =
+    -DOLED_LCD=true 
+    -DSerialDebug=false
+    -DEnableHumidityControlSupport=false
+    -DEanbleParasiteTempControl=false
+    -DEnableBME280Support=false
+    -DSONOFF_NEWGEN=true
 
 monitor_speed = 115200
 lib_deps = ${common_env_data.lib_deps_external_esp32} 

--- a/src/BrewPiLess.cpp
+++ b/src/BrewPiLess.cpp
@@ -1702,7 +1702,7 @@ void handleReset()
 
 void brewpi_setup()
 {
-	if (SONOFF_NEWGEN) {
+	if (SONOFF_TH_ELITE_ORIGIN) {
 		pinMode(sensorPowerPin, OUTPUT);  // Power for sonoff temp sensor
 		digitalWrite(sensorPowerPin, HIGH);
 		pinMode(powerIndicatorPin, OUTPUT); 

--- a/src/BrewPiLess.cpp
+++ b/src/BrewPiLess.cpp
@@ -1702,7 +1702,12 @@ void handleReset()
 
 void brewpi_setup()
 {
-
+	if (SONOFF_NEWGEN) {
+		pinMode(sensorPowerPin, OUTPUT);  // Power for sonoff temp sensor
+		digitalWrite(sensorPowerPin, HIGH);
+		pinMode(powerIndicatorPin, OUTPUT); 
+		digitalWrite(powerIndicatorPin, LOW); // Red power led	
+	}
 #if defined(ESP8266)
 	// We need to initialize the EEPROM on ESP8266
 	EEPROM.begin(MAX_EEPROM_SIZE_LIMIT);

--- a/src/Config.h
+++ b/src/Config.h
@@ -313,8 +313,8 @@
 
 #endif
 
-#ifndef SONOFF_NEWGEN
-#define SONOFF_NEWGEN false
+#ifndef SONOFF_TH_ELITE_ORIGIN
+#define SONOFF_TH_ELITE_ORIGIN false
 #endif
 
 #if ESP32
@@ -348,7 +348,7 @@
 // pins
 #ifdef ESP32
 
-#if SONOFF_NEWGEN
+#if SONOFF_TH_ELITE_ORIGIN
 
 #define PIN_SCL 17 // TM1621 CS
 #define PIN_SDA 18 // TM1621 WR
@@ -361,7 +361,7 @@
 #define actuatorPin3  5   // TM1621 DAT
 #define actuatorPin4  24  
 #define actuatorPin5  26
-#else // SONOFF_NEWGEN ends
+#else // SONOFF_TH_ELITE_ORIGIN ends
 
 #define PIN_SDA 21
 #define PIN_SCL 22
@@ -393,7 +393,7 @@
 // 34,35,66,39 input only
 #define rotaryAPin      32
 #define rotaryBPin      33
-#if SONOFF_NEWGEN
+#if SONOFF_TH_ELITE_ORIGIN
 #define rotarySwitchPin 35
 #else
 #define rotarySwitchPin 25

--- a/src/Config.h
+++ b/src/Config.h
@@ -313,6 +313,10 @@
 
 #endif
 
+#ifndef SONOFF_NEWGEN
+#define SONOFF_NEWGEN false
+#endif
+
 #if ESP32
 #define FS_EEPROM true
 #endif
@@ -344,6 +348,21 @@
 // pins
 #ifdef ESP32
 
+#if SONOFF_NEWGEN
+
+#define PIN_SCL 17 // TM1621 CS
+#define PIN_SDA 18 // TM1621 WR
+
+
+#define oneWirePin 25
+
+#define actuatorPin1  21  // This is relay 1
+#define actuatorPin2  23  // TM1621 RD
+#define actuatorPin3  5   // TM1621 DAT
+#define actuatorPin4  24  
+#define actuatorPin5  26
+#else // SONOFF_NEWGEN ends
+
 #define PIN_SDA 21
 #define PIN_SCL 22
 
@@ -355,6 +374,8 @@
 #define actuatorPin3  19
 #define actuatorPin4  27
 #define actuatorPin5  26
+
+#endif 
 
 #if MORE_PINS_CONFIGURATION
 
@@ -368,13 +389,19 @@
 #else
 #define BuzzPin       18
 #endif
+
 // 34,35,66,39 input only
 #define rotaryAPin      32
 #define rotaryBPin      33
+#if SONOFF_NEWGEN
+#define rotarySwitchPin 35
+#else
 #define rotarySwitchPin 25
+#endif
 
 // Only ADC1 (pin 32~39) is allowed 
 #define PressureAdcPin  36
+
 
 #else // #ifdef ESP32
 #define NODEMCU_PIN_A0 17	// Analog

--- a/src/Pins.h
+++ b/src/Pins.h
@@ -98,7 +98,7 @@
 #endif
 #endif
 
-#if SONOFF_NEWGEN
+#if SONOFF_TH_ELITE_ORIGIN
 #ifndef powerIndicatorPin
 #define powerIndicatorPin 16
 #endif

--- a/src/Pins.h
+++ b/src/Pins.h
@@ -97,6 +97,21 @@
 #define fridgeSensorPin  11
 #endif
 #endif
+
+#if SONOFF_NEWGEN
+#ifndef powerIndicatorPin
+#define powerIndicatorPin 16
+#endif
+#ifndef relayIndicatorPin
+#define relayIndicatorPin 13
+#endif
+#ifndef wifiIndicatorPin
+#define wifiIndicatorPin 15
+#endif
+#ifndef sensorPowerPin
+#define sensorPowerPin 27
+#endif
+#endif
 // Pay attention when changing the pins for the rotary encoder.
 // They should be connected to external interrupt INT0, INT1 and INT3
 

--- a/src/TempControl.cpp
+++ b/src/TempControl.cpp
@@ -78,7 +78,7 @@ uint16_t TempControl::waitTime;
 #endif
 
 void TempControl::init(void){
-	if (SONOFF_NEWGEN) {
+	if (SONOFF_TH_ELITE_ORIGIN) {
 		pinMode(relayIndicatorPin, OUTPUT);
 	}
 	state=IDLE;
@@ -402,7 +402,7 @@ void TempControl::updateOutputs(void) {
 	heater->setActive(!cc.lightAsHeater && heating);
 	light->setActive(isDoorOpen() || (cc.lightAsHeater && heating) || cameraLightState.isActive());
 	fan->setActive(heating || cooling);
-	if (SONOFF_NEWGEN && (heating || cooling)) {
+	if (SONOFF_TH_ELITE_ORIGIN && (heating || cooling)) {
   		digitalWrite(relayIndicatorPin, LOW);
 	}
 	else {

--- a/src/TempControl.cpp
+++ b/src/TempControl.cpp
@@ -31,6 +31,7 @@
 #include "EepromManager.h"
 #include "TempSensorDisconnected.h"
 #include "RotaryEncoder.h"
+#include "Config.h"
 
 TempControl tempControl;
 
@@ -77,6 +78,9 @@ uint16_t TempControl::waitTime;
 #endif
 
 void TempControl::init(void){
+	if (SONOFF_NEWGEN) {
+		pinMode(relayIndicatorPin, OUTPUT);
+	}
 	state=IDLE;
 	cs.mode = MODE_OFF;
 
@@ -398,6 +402,12 @@ void TempControl::updateOutputs(void) {
 	heater->setActive(!cc.lightAsHeater && heating);
 	light->setActive(isDoorOpen() || (cc.lightAsHeater && heating) || cameraLightState.isActive());
 	fan->setActive(heating || cooling);
+	if (SONOFF_NEWGEN && (heating || cooling)) {
+  		digitalWrite(relayIndicatorPin, LOW);
+	}
+	else {
+		digitalWrite(relayIndicatorPin, HIGH);
+	}
 }
 
 

--- a/src/WiFiSetup.cpp
+++ b/src/WiFiSetup.cpp
@@ -84,7 +84,7 @@ bool WiFiSetupClass::isApMode(){
 void WiFiSetupClass::begin(WiFiMode mode, char const *ssid,const char *passwd,char const* targetSSID,const char *targetPass)
 {
 	wifi_info("begin:");
-	if(SONOFF_NEWGEN) {
+	if(SONOFF_TH_ELITE_ORIGIN) {
 		pinMode(wifiIndicatorPin, OUTPUT); // Blue Wifi led
 	}
 	if(targetSSID && targetSSID[0]){
@@ -195,7 +195,7 @@ String WiFiSetupClass::status(void){
 
 bool WiFiSetupClass::stayConnected(void)
 {
-	if(SONOFF_NEWGEN) {
+	if(SONOFF_TH_ELITE_ORIGIN) {
 		digitalWrite(wifiIndicatorPin, HIGH);
 	}
 	if(WiFi.getMode() == WIFI_AP || WiFi.getMode() == WIFI_AP_STA){
@@ -348,7 +348,7 @@ bool WiFiSetupClass::stayConnected(void)
  	} // WiFi.status() != WL_CONNECTED 
  	else // connected
  	{
-		 if(SONOFF_NEWGEN) {
+		 if(SONOFF_TH_ELITE_ORIGIN) {
 		 	digitalWrite(wifiIndicatorPin, LOW);
 		 }
 		 if(_mode == WIFI_AP){

--- a/src/WiFiSetup.cpp
+++ b/src/WiFiSetup.cpp
@@ -8,6 +8,7 @@
 #include <nvs.h>
 #include <nvs_flash.h>
 #include <ESPmDNS.h>
+#include "Pins.h"
 #endif
 
 //needed for library
@@ -83,7 +84,9 @@ bool WiFiSetupClass::isApMode(){
 void WiFiSetupClass::begin(WiFiMode mode, char const *ssid,const char *passwd,char const* targetSSID,const char *targetPass)
 {
 	wifi_info("begin:");
-	
+	if(SONOFF_NEWGEN) {
+		pinMode(wifiIndicatorPin, OUTPUT); // Blue Wifi led
+	}
 	if(targetSSID && targetSSID[0]){
 		if(_targetSSID) free((void*)_targetSSID);
 		_targetSSID=strdup(targetSSID);
@@ -192,6 +195,9 @@ String WiFiSetupClass::status(void){
 
 bool WiFiSetupClass::stayConnected(void)
 {
+	if(SONOFF_NEWGEN) {
+		digitalWrite(wifiIndicatorPin, HIGH);
+	}
 	if(WiFi.getMode() == WIFI_AP || WiFi.getMode() == WIFI_AP_STA){
 		dnsServer->processNextRequest();
 //		if(_mode == WIFI_AP) return true;
@@ -342,6 +348,9 @@ bool WiFiSetupClass::stayConnected(void)
  	} // WiFi.status() != WL_CONNECTED 
  	else // connected
  	{
+		 if(SONOFF_NEWGEN) {
+		 	digitalWrite(wifiIndicatorPin, LOW);
+		 }
 		 if(_mode == WIFI_AP){
 			 DBG_PRINTF("Connected in AP_mode\n");
 		 }else{


### PR DESCRIPTION
Great work! Thank you so much! Since we don't when or how Sonoff is going to update their products and how long the **current generation** is going to be the **new generation** I'd recommend calling the env and preprocessor definitions by the products' names instead of "NEWGEN".